### PR TITLE
Add owner/support metadata to configuration

### DIFF
--- a/bot/config.py
+++ b/bot/config.py
@@ -11,6 +11,9 @@ class Config:
     OWNER_ID: int
     ADMIN_IDS: list
     BANNER_URL: str
+    OWNER_URL: str
+    DEVELOPER_URL: str
+    SUPPORT_URL: str
     USE_WEBHOOK: bool
     WEBHOOK_HOST: str
     WEBHOOK_PATH: str
@@ -35,7 +38,10 @@ def load_config() -> Config:
         ADMIN_IDS=[
             int(x) for x in os.getenv("ADMIN_IDS", "").replace(" ", "").split(",") if x
         ],
-        BANNER_URL=os.getenv("BANNER_URL", ""),
+        BANNER_URL="https://graph.org/file/1200bc92e8816982887fe-d272d0fddc2a392fed.jpg",
+        OWNER_URL="https://t.me/oxeign",
+        DEVELOPER_URL="https://t.me/oxeign",
+        SUPPORT_URL="https://t.me/botdukan",
         USE_WEBHOOK=parse_bool(os.getenv("USE_WEBHOOK", "false")),
         WEBHOOK_HOST=os.getenv("WEBHOOK_HOST", ""),
         WEBHOOK_PATH=os.getenv("WEBHOOK_PATH", "/telegram-webhook"),


### PR DESCRIPTION
## Summary
- add owner, developer, and support URLs to configuration defaults
- set default banner image URL

## Testing
- `python -m py_compile bot/config.py`


------
https://chatgpt.com/codex/tasks/task_b_68a5f90a67fc83308ff802d06e198e47