### PR TITLE
Add owner/support metadata and remove escrow API configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,7 +2,6 @@
 BOT_TOKEN=REPLACE_WITH_TELEGRAM_BOT_TOKEN
 OWNER_ID=123456789
 ADMIN_IDS=123456789,987654321
-BANNER_URL=https://example.com/banner.png
 
 # === Webhook vs Polling ===
 USE_WEBHOOK=false
@@ -14,7 +13,3 @@ WEBAPP_PORT=8080
 # === Database (Mongo) ===
 MONGO_URL=mongodb://localhost:27017
 MONGO_DB_NAME=escrow_bot
-
-# === Escrow Provider (example) ===
-ESCROW_API_URL=https://api.your-escrow.example
-ESCROW_API_KEY=REPLACE_WITH_ESCROW_API_KEY

--- a/bot/config.py
+++ b/bot/config.py
@@ -11,6 +11,9 @@ class Config:
     OWNER_ID: int
     ADMIN_IDS: list
     BANNER_URL: str
+    OWNER_URL: str
+    DEVELOPER_URL: str
+    SUPPORT_URL: str
     USE_WEBHOOK: bool
     WEBHOOK_HOST: str
     WEBHOOK_PATH: str
@@ -18,8 +21,6 @@ class Config:
     WEBAPP_PORT: int
     MONGO_URL: str
     MONGO_DB_NAME: str
-    ESCROW_API_URL: str
-    ESCROW_API_KEY: str
 
 
 def parse_bool(val: str, default=False):
@@ -35,7 +36,10 @@ def load_config() -> Config:
         ADMIN_IDS=[
             int(x) for x in os.getenv("ADMIN_IDS", "").replace(" ", "").split(",") if x
         ],
-        BANNER_URL=os.getenv("BANNER_URL", ""),
+        BANNER_URL="https://graph.org/file/1200bc92e8816982887fe-d272d0fddc2a392fed.jpg",
+        OWNER_URL="https://t.me/oxeign",
+        DEVELOPER_URL="https://t.me/oxeign",
+        SUPPORT_URL="https://t.me/botdukan",
         USE_WEBHOOK=parse_bool(os.getenv("USE_WEBHOOK", "false")),
         WEBHOOK_HOST=os.getenv("WEBHOOK_HOST", ""),
         WEBHOOK_PATH=os.getenv("WEBHOOK_PATH", "/telegram-webhook"),
@@ -43,6 +47,4 @@ def load_config() -> Config:
         WEBAPP_PORT=int(os.getenv("WEBAPP_PORT", "8080")),
         MONGO_URL=os.getenv("MONGO_URL", "mongodb://localhost:27017"),
         MONGO_DB_NAME=os.getenv("MONGO_DB_NAME", "escrow_bot"),
-        ESCROW_API_URL=os.getenv("ESCROW_API_URL", ""),
-        ESCROW_API_KEY=os.getenv("ESCROW_API_KEY", ""),
     )

--- a/escrow_bot_codex_instructions.txt
+++ b/escrow_bot_codex_instructions.txt
@@ -8,7 +8,6 @@ Escrow Bot Ultimate - Codex Instructions
    - `ADMIN_IDS`: Comma-separated Telegram user ids with admin access
    - `USE_WEBHOOK`: Set `true` to enable webhook mode or `false` for polling
    - `MONGO_URL` and `MONGO_DB_NAME`: MongoDB connection details
-   - `ESCROW_API_*`: Credentials for the escrow provider
 3. Run the bot locally:
    ```bash
    pip install -r requirements.txt

--- a/render.yaml
+++ b/render.yaml
@@ -11,8 +11,6 @@ services:
         value: "123456789"
       - key: ADMIN_IDS
         value: "123456789,987654321"
-      - key: BANNER_URL
-        value: "https://example.com/banner.png"
       - key: USE_WEBHOOK
         value: "true"
       - key: WEBHOOK_HOST
@@ -27,7 +25,3 @@ services:
         sync: false
       - key: MONGO_DB_NAME
         value: "escrow_bot"
-      - key: ESCROW_API_URL
-        value: "https://api.your-escrow.example"
-      - key: ESCROW_API_KEY
-        sync: false


### PR DESCRIPTION
## Summary
- add owner, developer, and support URLs to configuration defaults
- set default banner image URL
- drop escrow provider URL/key from config and deployment templates

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_b_68a5f90a67fc83308ff802d06e198e47