### PR TITLE
Pin aiohttp to 3.8.x for aiogram compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,6 @@ pydantic==2.8.2
 python-dotenv==1.0.1
 uvloop==0.19.0; sys_platform != 'win32'
 ujson==5.10.0
-aiohttp==3.9.5
+# aiogram 2.x requires aiohttp <3.9.0
+aiohttp==3.8.6
 loguru==0.7.2


### PR DESCRIPTION
## Summary
- align `aiohttp` with aiogram's requirement by pinning it to 3.8.6
- document the dependency constraint in `requirements.txt`

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement aiogram==2.25.1 — Cannot connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_b_68a5fc295d788330b45effdb720b99ec