### PR TITLE
Enhance bot UX with help command and clarify Python requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ A production-ready Telegram escrow bot with webhook & polling support, MongoDB s
 - Blacklist/scammer detection
 - Safe MarkdownV2/HTML rendering
 
+## Requirements
+- Python 3.11 (Python 3.12 is not yet supported due to `aiohttp` build issues)
+
 ## Installation
 ### Using pip
 ```bash

--- a/bot/buttons.py
+++ b/bot/buttons.py
@@ -7,9 +7,13 @@ from aiogram.types import (
 
 
 def main_menu():
+    """Main reply keyboard shown on /start."""
     kb = ReplyKeyboardMarkup(resize_keyboard=True)
-    kb.add(KeyboardButton("🛡️ Start Escrow (/escrow)"))
-    kb.add(KeyboardButton("🆘 Support (/support)"))
+    kb.row(
+        KeyboardButton("🛡️ Escrow"),
+        KeyboardButton("🆘 Support"),
+    )
+    kb.add(KeyboardButton("ℹ️ Help"))
     return kb
 
 

--- a/bot/handlers.py
+++ b/bot/handlers.py
@@ -14,8 +14,8 @@ def register_handlers(dp: Dispatcher, banner_url: str):
         txt = (
             "*Escrow Bot Ultimate*\n"
             "\n"
-            "Secure deals with buyer/seller escrow.\n"
-            "Use /escrow to begin."
+            "💼 Secure peer‑to‑peer trades with escrow.\n"
+            "Press 🛡️ Escrow to begin or ℹ️ Help for guidance."
         )
         if banner_url:
             try:
@@ -35,6 +35,19 @@ def register_handlers(dp: Dispatcher, banner_url: str):
     @dp.message_handler(commands=["support"])
     async def cmd_support(msg: types.Message):
         await support_message(msg, banner_url)
+
+    @dp.message_handler(commands=["help"])
+    async def cmd_help(msg: types.Message):
+        txt = (
+            "*How to use the bot*\n"
+            "\n"
+            "🛡️ /escrow – start a protected deal\n"
+            "🆘 /support – talk to support or view the FAQ\n"
+            "⚖️ /dispute – open a dispute with your Escrow ID\n"
+        )
+        await msg.answer(
+            md2_escape(txt), parse_mode="MarkdownV2", reply_markup=main_menu()
+        )
 
     @dp.message_handler(commands=["escrow"])
     async def cmd_escrow(msg: types.Message):
@@ -73,6 +86,8 @@ def register_handlers(dp: Dispatcher, banner_url: str):
             await cmd_escrow(msg)
         elif "support" in text:
             await cmd_support(msg)
+        elif "help" in text:
+            await cmd_help(msg)
         else:
             await msg.answer(
                 md2_escape("Use /escrow to start or /support for help."),

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,6 @@ pydantic==2.8.2
 python-dotenv==1.0.1
 uvloop==0.19.0; sys_platform != 'win32'
 ujson==5.10.0
-# aiogram 2.x requires aiohttp <3.9.0
+# aiohttp 3.8.x supports Python up to 3.11
 aiohttp==3.8.6
 loguru==0.7.2


### PR DESCRIPTION
## Summary
- add a `/help` command and button for quick guidance
- improve main menu button layout with emojis
- document Python 3.11 requirement due to `aiohttp` compatibility

## Testing
- `python -m py_compile Escrow/bot/buttons.py Escrow/bot/handlers.py`

------
https://chatgpt.com/codex/tasks/task_b_68a5ff1b7dc08330b5bf0bd3cb5983a7