### PR TITLE
Pin pydantic v1 and fix lint workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.x'
+          python-version: '3.11'
       - name: Install dependencies
         run: |
           pip install flake8 black

--- a/admin/cli.py
+++ b/admin/cli.py
@@ -19,6 +19,7 @@ ROOT_DIR = Path(__file__).resolve().parents[1]
 if str(ROOT_DIR) not in sys.path:
     sys.path.append(str(ROOT_DIR))
 
+
 async def main():
     parser = argparse.ArgumentParser(description="Admin panel CLI")
     sub = parser.add_subparsers(dest="cmd")

--- a/bot/handlers.py
+++ b/bot/handlers.py
@@ -11,6 +11,7 @@ from bot.config import load_config
 
 def register_handlers(dp: Dispatcher, banner_url: str):
     cfg = load_config()
+
     @dp.message_handler(commands=["start"])
     async def start(msg: types.Message):
         txt = (

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 aiogram==2.25.1
 motor==3.3.2
-pydantic==2.8.2
+pydantic==1.10.12
 python-dotenv==1.0.1
 uvloop==0.19.0; sys_platform != 'win32'
 ujson==5.10.0


### PR DESCRIPTION
## Summary
- Pin pydantic to v1 to resolve dependency conflicts
- Run lint workflow on Python 3.11 for uvloop compatibility
- Format CLI and handler modules to satisfy Black

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `flake8 .` *(fails: command not found)*
- `black --check .`


------
https://chatgpt.com/codex/tasks/task_b_68a601a426708330a8f7d398385e5aac