### PR TITLE
Ensure bot package import when running main module

### DIFF
--- a/bot/main.py
+++ b/bot/main.py
@@ -1,9 +1,16 @@
+import asyncio
 import logging
+import sys
+from pathlib import Path
+
 from aiogram import Bot, Dispatcher
 from aiogram.contrib.fsm_storage.memory import MemoryStorage
 from aiogram.utils.executor import start_polling
 from loguru import logger
-import asyncio
+
+ROOT_DIR = Path(__file__).resolve().parent.parent
+if str(ROOT_DIR) not in sys.path:
+    sys.path.append(str(ROOT_DIR))
 
 from bot.config import load_config
 from bot.handlers import register_handlers


### PR DESCRIPTION
## Summary
- add repository root to `sys.path` in `bot/main.py` so `from bot...` imports work when executed directly

## Testing
- `python -m py_compile bot/main.py`
- `python -c "import bot.main"` *(fails: ModuleNotFoundError: No module named 'aiogram')*


------
https://chatgpt.com/codex/tasks/task_b_68a61aa5405c83308b64ff921324e695