### PR TITLE
fix: escape support fallback

### DIFF
--- a/bot/support.py
+++ b/bot/support.py
@@ -21,4 +21,9 @@ async def support_message(msg: types.Message, banner_url: str):
             return
         except:  # fallback to text
             pass
-    await msg.answer(text, parse_mode="MarkdownV2", reply_markup=support_buttons())
+    # Ensure MarkdownV2 safety even in text fallback
+    await msg.answer(
+        md2_escape(text),
+        parse_mode="MarkdownV2",
+        reply_markup=support_buttons(),
+    )


### PR DESCRIPTION
## Summary
- escape support text fallback using MarkdownV2 safe formatting

## Testing
- `python -m py_compile bot/support.py bot/handlers.py`


------
https://chatgpt.com/codex/tasks/task_b_68a620bcc4dc8330ad730b221096e138