### PR TITLE
Handle invalid counterparty id

### DIFF
--- a/bot/wizard.py
+++ b/bot/wizard.py
@@ -141,9 +141,13 @@ def register_wizard(dp: Dispatcher):
         try:
             seller_id = int(cp) if role == "buyer" else cb.from_user.id
             buyer_id = cb.from_user.id if role == "buyer" else int(cp)
-        except Exception:
-            seller_id = cb.from_user.id if role == "seller" else None
-            buyer_id = cb.from_user.id if role == "buyer" else None
+        except ValueError:
+            await cb.message.answer(
+                "❌ Counterparty ID must be a numeric Telegram ID."
+            )
+            await state.finish()
+            await cb.answer()
+            return
 
         payload = {
             "buyer_id": buyer_id,


### PR DESCRIPTION
## Summary
- handle invalid counterparty ID in wizard to prevent creating escrows with missing buyer/seller IDs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68a6221a0bdc8330872a5afad122dd69