### PR TITLE
feat: enhance support messaging

### DIFF
--- a/bot/handlers.py
+++ b/bot/handlers.py
@@ -135,7 +135,8 @@ def register_handlers(dp: Dispatcher, banner_url: str):
     @dp.callback_query_handler(lambda c: c.data in {"support_contact", "support_faq"})
     async def cb_support_buttons(cb: types.CallbackQuery):
         if cb.data == "support_contact":
-            await cb.message.answer(md2_escape("Contact @support"), parse_mode="MarkdownV2")
+            text = "Support: https://t.me/botdukan\nDeveloper @oxeign"
+            await cb.message.answer(md2_escape(text), parse_mode="MarkdownV2")
         else:
             await cb.message.answer(md2_escape("FAQ: https://example.com/faq"), parse_mode="MarkdownV2")
         await cb.answer()

--- a/bot/support.py
+++ b/bot/support.py
@@ -4,12 +4,39 @@ from bot.utils import md2_escape
 
 
 async def support_message(msg: types.Message, banner_url: str):
+    """
+    Send support information depending on chat type.
+
+    In group chats, the bot reports the group owner's Telegram ID.
+    In private chats, it shares the support URL and developer contact.
+    """
+
+    # Group chats: show group owner ID
+    if msg.chat.type in {"group", "supergroup"}:
+        owner_id = "unknown"
+        try:
+            admins = await msg.bot.get_chat_administrators(msg.chat.id)
+            for admin in admins:
+                if admin.status == "creator":
+                    owner_id = str(admin.user.id)
+                    break
+        except Exception:
+            pass
+        text = f"Group owner ID: {owner_id}"
+        await msg.answer(md2_escape(text), parse_mode="MarkdownV2")
+        return
+
+    # Private chats: provide support links
     text = (
         f"*Support Center*\n"
-        f"Need help? Tap a button below or message our admins.\n"
+        f"Need help? Contact our support or developer.\n"
+        f"\n"
+        f"https://t.me/botdukan\n"
+        f"Developer @oxeign\n"
         f"\n"
         f"• For disputes, use /dispute while referencing your Escrow ID.\n"
     )
+
     if banner_url:
         try:
             await msg.answer_photo(
@@ -19,6 +46,7 @@ async def support_message(msg: types.Message, banner_url: str):
                 reply_markup=support_buttons(),
             )
             return
-        except:  # fallback to text
+        except Exception:  # fallback to text
             pass
-    await msg.answer(text, parse_mode="MarkdownV2", reply_markup=support_buttons())
+
+    await msg.answer(md2_escape(text), parse_mode="MarkdownV2", reply_markup=support_buttons())


### PR DESCRIPTION
## Summary
- show group owner ID when /support is used in groups
- provide support URL and developer contact in private chats
- update support button handler to share new link

## Testing
- `python -m py_compile bot/support.py bot/handlers.py`

------
https://chatgpt.com/codex/tasks/task_b_68a624c90db88330907db2222cfef151