### PR TITLE
Fix escrow confirmation and add URL-based support

### DIFF
--- a/bot/buttons.py
+++ b/bot/buttons.py
@@ -40,10 +40,10 @@ def confirm_buttons():
     ik.add(InlineKeyboardButton("❌ Cancel", callback_data="confirm_no"))
     return ik
 
-
-def support_buttons():
+def support_buttons(support_url: str):
+    # Open the configured URL directly (e.g. https://t.me/support_handle)
     ik = InlineKeyboardMarkup()
-    ik.add(InlineKeyboardButton("📨 Contact Support", callback_data="support_contact"))
+    ik.add(InlineKeyboardButton("📨 Contact Support", url=support_url))
     ik.add(InlineKeyboardButton("📜 FAQ", callback_data="support_faq"))
     return ik
 

--- a/bot/handlers.py
+++ b/bot/handlers.py
@@ -11,27 +11,16 @@ from database.mongo import db
 def register_handlers(dp: Dispatcher, banner_url: str):
     cfg = load_config()
 
-    # Wizard
+    # Wizard routes
     register_wizard(dp)
 
     @dp.message_handler(commands=["start"])
     async def cmd_start(msg: types.Message):
         text = (
-            "*Escrow Bot Ultimate*\n"
+            "*Escrow Bot*\n"
             "Create safe escrow deals in a few guided steps.\n\n"
             "Use /escrow to begin, /help for commands, or /support for assistance."
         )
-        if banner_url:
-            try:
-                await msg.answer_photo(
-                    banner_url,
-                    caption=md2_escape(text),
-                    parse_mode="MarkdownV2",
-                    reply_markup=main_menu(),
-                )
-                return
-            except Exception:
-                pass
         await msg.answer(md2_escape(text), parse_mode="MarkdownV2", reply_markup=main_menu())
 
     @dp.message_handler(commands=["help"])
@@ -125,12 +114,8 @@ def register_handlers(dp: Dispatcher, banner_url: str):
         else:
             await msg.answer(md2_escape("Use /escrow to start or /support for help."), parse_mode="MarkdownV2")
 
-    @dp.callback_query_handler(lambda c: c.data in {"support_contact", "support_faq"})
+    @dp.callback_query_handler(lambda c: c.data == "support_faq")
     async def cb_support_buttons(cb: types.CallbackQuery):
-        if cb.data == "support_contact":
-            text = "Support: https://t.me/botdukan\nDeveloper @oxeign"
-            await cb.message.answer(md2_escape(text), parse_mode="MarkdownV2")
-        else:
-            await cb.message.answer(md2_escape("FAQ: https://example.com/faq"), parse_mode="MarkdownV2")
+        await cb.message.answer(md2_escape("FAQ: https://example.com/faq"), parse_mode="MarkdownV2")
         await cb.answer()
 

--- a/bot/support.py
+++ b/bot/support.py
@@ -1,52 +1,25 @@
 from aiogram import types
 from bot.buttons import support_buttons
 from bot.utils import md2_escape
-
+from bot.config import load_config
 
 async def support_message(msg: types.Message, banner_url: str):
-    """
-    Send support information depending on chat type.
-
-    In group chats, the bot reports the group owner's Telegram ID.
-    In private chats, it shares the support URL and developer contact.
-    """
-
-    # Group chats: show group owner ID
-    if msg.chat.type in {"group", "supergroup"}:
-        owner_id = "unknown"
-        try:
-            admins = await msg.bot.get_chat_administrators(msg.chat.id)
-            for admin in admins:
-                if admin.status == "creator":
-                    owner_id = str(admin.user.id)
-                    break
-        except Exception:
-            pass
-        text = f"Group owner ID: {owner_id}"
-        await msg.answer(md2_escape(text), parse_mode="MarkdownV2")
-        return
-
-    # Private chats: provide support links
+    cfg = load_config()
     text = (
-        f"*Support Center*\n"
-        f"Need help? Contact our support or developer.\n"
-        f"\n"
-        f"https://t.me/botdukan\n"
-        f"Developer @oxeign\n"
-        f"\n"
-        f"• For disputes, use /dispute while referencing your Escrow ID.\n"
+        f"*Support Center*\\n"
+        f"Need help? Tap a button below or message our admins.\\n\\n"
+        f"• For disputes, use /dispute while referencing your Escrow ID.\\n"
     )
-
+    kb = support_buttons(cfg.SUPPORT_URL)
     if banner_url:
         try:
             await msg.answer_photo(
                 banner_url,
                 caption=md2_escape(text),
                 parse_mode="MarkdownV2",
-                reply_markup=support_buttons(),
+                reply_markup=kb,
             )
             return
-        except Exception:  # fallback to text
+        except Exception:
             pass
-
-    await msg.answer(md2_escape(text), parse_mode="MarkdownV2", reply_markup=support_buttons())
+    await msg.answer(md2_escape(text), parse_mode="MarkdownV2", reply_markup=kb)


### PR DESCRIPTION
## Summary
- Ack confirm callbacks early and report DB errors
- Add URL support button and pass configured SUPPORT_URL
- Simplify start/support handlers and improve cancel logic

## Testing
- `pytest -q`
- `python -m py_compile bot/buttons.py bot/support.py bot/wizard.py bot/handlers.py`


------
https://chatgpt.com/codex/tasks/task_b_68a62ba602248330a6fd1cff04427359