### PR TITLE
Fix aiogram polling and session cleanup

### DIFF
--- a/bot/main.py
+++ b/bot/main.py
@@ -42,16 +42,14 @@ async def main():
         if cfg.USE_WEBHOOK:
             await run_webhook(bot, dp)
         else:
-            await dp.start_polling(
-                skip_updates=True,
-                on_startup=on_startup,
-            )
+            await dp.start_polling(on_startup=on_startup)
     except exceptions.TerminatedByOtherGetUpdates:
         logger.error(
             "Another instance of the bot is running. Please ensure only one bot instance runs at a time."
         )
     finally:
-        await bot.session.close()
+        session = await bot.get_session()
+        await session.close()
         logger.info("🛑 Bot shutdown complete")
 
 

--- a/webhooks/handler.py
+++ b/webhooks/handler.py
@@ -23,7 +23,6 @@ async def run_webhook(bot: Bot, dp: Dispatcher):
         webhook_path=cfg.WEBHOOK_PATH,
         on_startup=on_startup,
         on_shutdown=on_shutdown,
-        skip_updates=True,
         host=cfg.WEBAPP_HOST,
         port=cfg.WEBAPP_PORT,
     )


### PR DESCRIPTION
## Summary
- remove unsupported `skip_updates` argument from `start_polling`
- close aiogram bot session safely via `get_session`
- drop unsupported `skip_updates` when starting webhook

## Testing
- `python -m py_compile bot/main.py webhooks/handler.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68a631c7420c8330a23ad041ddfbf227