### PR TITLE
Fix bot module import path issue

### DIFF
--- a/bot/main.py
+++ b/bot/main.py
@@ -1,8 +1,15 @@
-import logging, asyncio
+import logging
+import asyncio
+import os
+import sys
+
 from aiogram import Bot, Dispatcher, types
 from aiogram.contrib.fsm_storage.memory import MemoryStorage
 from aiogram.utils.executor import start_polling
 from loguru import logger
+
+# Ensure project root is in the Python path when executed directly
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from bot.config import load_config
 from bot.handlers import register_handlers


### PR DESCRIPTION
## Summary
- ensure project root is added to Python path before importing bot modules

## Testing
- `python -m py_compile bot/main.py`
- `pytest`
- `BOT_TOKEN=dummy OWNER_ID=1 USE_WEBHOOK=false MONGO_URL="mongodb://invalid" python bot/main.py` *(fails: No module named 'aiogram')*


------
https://chatgpt.com/codex/tasks/task_b_68a6909820848330b51dbbd4a32e17e5